### PR TITLE
Fix bug in max potential calculation

### DIFF
--- a/discrete_diffusion/fkd_class.py
+++ b/discrete_diffusion/fkd_class.py
@@ -161,7 +161,8 @@ class FKD:
 
         # Compute potentials
         if self.potential_type == PotentialType.MAX:
-            w = torch.exp(self.lmbda * torch.max(rs_candidates, self.population_rs))
+            rs_candidates = torch.max(rs_candidates, self.population_rs)
+            w = torch.exp(self.lmbda * rs_candidates)
         elif self.potential_type == PotentialType.ADD:
             rs_candidates = rs_candidates + self.population_rs
             w = torch.exp(self.lmbda * rs_candidates)

--- a/text_to_image/fkd_diffusers/fkd_class.py
+++ b/text_to_image/fkd_diffusers/fkd_class.py
@@ -108,7 +108,8 @@ class FKD:
 
         # Compute importance weights
         if self.potential_type == PotentialType.MAX:
-            w = torch.exp(self.lmbda * torch.max(rs_candidates, self.population_rs))
+            rs_candidates = torch.max(rs_candidates, self.population_rs)
+            w = torch.exp(self.lmbda * rs_candidates)
         elif self.potential_type == PotentialType.ADD:
             rs_candidates = rs_candidates + self.population_rs
             w = torch.exp(self.lmbda * rs_candidates)


### PR DESCRIPTION
Fixes a bug when computing the Max potential in the FK Steering opensource implementation. Rather than computing a max over **all** steps, the old code was computing a max over just the previous intermediate step.

This issue was identified by @Yugomee.