### PR TITLE
Adds rt potential (reward at current timestep)

### DIFF
--- a/discrete_diffusion/fkd_class.py
+++ b/discrete_diffusion/fkd_class.py
@@ -23,6 +23,8 @@ class PotentialType(Enum):
     DIFF = "diff"
     MAX = "max"
     ADD = "add"
+    RT = "rt"
+
     BON = "bon"  # Returns sorted particles
     IS = "is"
 
@@ -169,17 +171,20 @@ class FKD:
         elif self.potential_type == PotentialType.DIFF:
             diffs = rs_candidates - self.population_rs
             w = torch.exp(self.lmbda * diffs)
+        elif self.potential_type == PotentialType.RT:
+            w = torch.exp(self.lmbda * rs_candidates)
         elif self.potential_type in [PotentialType.BON, PotentialType.IS]:
             assert at_terminal_sample
             w = torch.exp(self.lmbda * rs_candidates)
         else:
             raise ValueError(f"potential_type {self.potential_type} not recognized")
 
-        # If we are at the last timestep, compute corrected potentials if using the MAX or ADD potential
+        # If we are at the last timestep, compute corrected potentials if using the MAX, ADD, or RT potential
         if at_terminal_sample:
             if (
                 self.potential_type == PotentialType.MAX
                 or self.potential_type == PotentialType.ADD
+                or self.potential_type == PotentialType.RT
             ):
                 w = torch.exp(self.lmbda * rs_candidates) / self.product_of_potentials
 

--- a/text_to_image/fkd_diffusers/fkd_class.py
+++ b/text_to_image/fkd_diffusers/fkd_class.py
@@ -13,6 +13,7 @@ class PotentialType(Enum):
     DIFF = "diff"
     MAX = "max"
     ADD = "add"
+    RT = "rt"
 
 
 class FKD:
@@ -116,6 +117,8 @@ class FKD:
         elif self.potential_type == PotentialType.DIFF:
             diffs = rs_candidates - self.population_rs
             w = torch.exp(self.lmbda * diffs)
+        elif self.potential_type == PotentialType.RT:
+            w = torch.exp(self.lmbda * rs_candidates)
         else:
             raise ValueError(f"potential_type {self.potential_type} not recognized")
 
@@ -123,6 +126,7 @@ class FKD:
             if (
                 self.potential_type == PotentialType.MAX
                 or self.potential_type == PotentialType.ADD
+                or self.potential_type == PotentialType.RT
             ):
                 w = torch.exp(self.lmbda * rs_candidates) / self.product_of_potentials
 


### PR DESCRIPTION
Add option to use exp(lambda*rt) as alternative potential.

TODO: We should consolidate the `fkd_class` logic in `discrete_diffusion/fkd_class.py` and `text_to_image/fkd_diffusers/fkd_class.py`.
